### PR TITLE
changed(TreeNode): React.Children not filtering NULL values.

### DIFF
--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -75,12 +75,15 @@ export type TreeNodeProps = React.PropsWithChildren<{
 }>;
 
 function TreeNode({ children, label, className }: TreeNodeProps) {
+
+  const filteredChildren = React.Children.toArray(children).filter((o: React.ReactNode) => o);
+
   return (
     <NodeContainer className={className}>
       {label}
-      {React.Children.count(children) > 0 && (
+      {filteredChildren.length ? (
         <ChildrenContainer>{children}</ChildrenContainer>
-      )}
+      ) : null}
     </NodeContainer>
   );
 }


### PR DESCRIPTION
TreeNode is rendering null nodes with a line that leads to nothing. This is an important fix if you have nodes that you want to situational render.