### PR TITLE
Fix Root node position

### DIFF
--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -5,6 +5,7 @@ import TreeNode, { TreeNodeProps } from './TreeNode';
 const TreeContainer = styled.ul<TreeProps>`
   padding-inline-start: 0;
   margin: 0;
+  display: flex;
 
   --line-height: ${({ lineHeight }) => lineHeight};
   --line-width: ${({ lineWidth }) => lineWidth};

--- a/src/components/__tests__/__snapshots__/Tree.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Tree.test.tsx.snap
@@ -4,6 +4,10 @@ exports[`Tree Renders 1`] = `
 .emotion-5 {
   padding-inline-start: 0;
   margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   --line-height: 20px;
   --line-width: 1px;
   --line-color: black;


### PR DESCRIPTION
Fix #1  

Add `display: flex;` to `TreeContainer` to fix the Root node position.