### PR TITLE
Fix line width and color documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Accepts the following props:
 - **label:** _**\(required\)**_ Any react `Node`
 - **children:** _**\(required\)**_ Any number of `<TreeNode>`
 - **lineHeight:** _\(default 20px\)_ The height of the Path as a [css length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
-- **lineWidth:** _\(default black\)_ The width of the Path as a [css length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
-- **lineColor:** _\(default 20px\)_ The color of the Path as a [css color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
+- **lineWidth:** _\(default 1px\)_ The width of the Path as a [css length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
+- **lineColor:** _\(default black\)_ The color of the Path as a [css color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
 - **lineBorderRadius:** _\(default 5px\)_ The color of the Path as a [css border-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
 - **nodePadding:** _\(default 5px\)_ The left and right padding of every `<TreeNode>` as a [css length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
 


### PR DESCRIPTION
The information for line width and color was swapped and the default value for the line width was wrong. This PR is a simple fix to the documentation.

_PS. Thank you for creating this package @daniel-hauser 🙏_