### PR TITLE
Centred childrenContainer line

### DIFF
--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -28,7 +28,7 @@ const childrenContainer = css`
 
   ::before {
     ${verticalLine};
-    left: 50%;
+    left: calc(50% - var(--tree-line-width) / 2);
     width: 0;
     border-left: var(--tree-line-width) var(--tree-node-line-style)
       var(--tree-line-color);


### PR DESCRIPTION
By default, the line between charts moves away on the left. The wider the line the worse it gets.
<img width="223" alt="Screenshot 2023-04-04 at 17 01 03" src="https://user-images.githubusercontent.com/53221160/229834452-550737d8-6dbc-45f6-8495-2332ccc2faf5.png">
